### PR TITLE
fix: prefix postinstall script with 'node'

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "test": "grunt test",
-    "postinstall": "scripts/postInstall.js"
+    "postinstall": "node scripts/postInstall.js"
   },
   "licenses": [
     {


### PR DESCRIPTION
The post install script fails on windows machines with this error message: 
"'scripts' is not recognized as an internal or external command, operable program or batch file". 

This change fixes it.